### PR TITLE
CORS Policy

### DIFF
--- a/example/gateway/gateway.go
+++ b/example/gateway/gateway.go
@@ -75,6 +75,8 @@ func loggingMiddleware(next http.Handler) http.Handler {
 		// Replace the original body with the TeeReader
 		r.Body = io.NopCloser(bodyReader)
 
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+
 		// Let the next handler read the body again
 		next.ServeHTTP(w, r)
 	})

--- a/example/gateway/gateway.go
+++ b/example/gateway/gateway.go
@@ -75,7 +75,7 @@ func loggingMiddleware(next http.Handler) http.Handler {
 		// Replace the original body with the TeeReader
 		r.Body = io.NopCloser(bodyReader)
 
-    w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 
 		// Let the next handler read the body again
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
Tools like Swagger UI require a broad [CORS policy](https://swagger.io/docs/open-source-tools/swagger-ui/usage/cors/).

This enables our example service to create that kind of broad policy, so that other tools (like a web UI...) could talk to them in the browser.