### PR TITLE
fix: make API required determinate

### DIFF
--- a/parser/utils.go
+++ b/parser/utils.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/aep-dev/aep-lib-go/pkg/openapi"
 	"github.com/aep-dev/aepc/schema"
@@ -68,6 +69,7 @@ func toOpenAPISchemaFromPropMap(propMap map[string]*schema.Property) (*openapi.S
 		}
 		field_numbers[int(p.GetNumber())] = name
 	}
+	sort.Strings(required)
 	return &openapi.Schema{
 		Type:             "object",
 		Properties:       properties,


### PR DESCRIPTION
there is some non-determinism due to map 
ordering in the generation of the API.

Fixing that to ensures tests pass.