### PR TITLE
chore: re-enable all OAS linter rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           ./scripts/run-oas-linter.sh
 
+      # currently disabled due to api-linter bugs:
+      # - https://github.com/aep-dev/api-linter/milestone/1
       # - name: run protobuf api-linter
       #   run: |
       #     ./scripts/run-api-linter.sh

--- a/scripts/run-oas-linter.sh
+++ b/scripts/run-oas-linter.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 if [ ! -f /tmp/spectral ]; then
-    curl "https://github.com/stoplightio/spectral/releases/download/v6.14.2/spectral-linux-x64" -o /tmp/spectral
+    curl -L "https://github.com/stoplightio/spectral/releases/download/v6.14.2/spectral-linux-x64" -o /tmp/spectral
     chmod +x /tmp/spectral
 fi
 
-/tmp/spectral lint --ruleset "./spectral.yaml" "./example/bookstore/v1/bookstore_openapi.yaml"
+exec /tmp/spectral lint --ruleset "./spectral.yaml" "./example/bookstore/v1/bookstore_openapi.yaml"

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -1,6 +1,3 @@
 extends:
-  - https://raw.githubusercontent.com/aep-dev/aep-openapi-linter/refs/heads/js-based-linter/spectral.yaml
-rules:
-  # disabling for now, as required path parameters (which are acceptable)
-  # will violate this rule.
-  aep-132-request-required-params: off
+  - https://raw.githubusercontent.com/aep-dev/aep-openapi-linter/acd68f74286e5af3b1244f58c70572ae0967e201/spectral.yaml
+rules: {}


### PR DESCRIPTION
The OAS linter has been fixed (https://github.com/aep-dev/aep-openapi-linter/pull/9), so re-enabling all linter rules.